### PR TITLE
Set updated_at on upsert and delete

### DIFF
--- a/lib/oplogjam/delete.rb
+++ b/lib/oplogjam/delete.rb
@@ -44,7 +44,7 @@ module Oplogjam
 
       table
         .where(id: row_id, deleted_at: nil)
-        .update(deleted_at: Time.now.utc)
+        .update(updated_at: Time.now.utc, deleted_at: Time.now.utc)
     end
   end
 end

--- a/lib/oplogjam/insert.rb
+++ b/lib/oplogjam/insert.rb
@@ -48,7 +48,6 @@ module Oplogjam
           conflict_where: { deleted_at: nil },
           update: {
             document: Sequel[:excluded][:document],
-            created_at: Time.now.utc,
             updated_at: Time.now.utc
           }
         )

--- a/spec/oplogjam/delete_spec.rb
+++ b/spec/oplogjam/delete_spec.rb
@@ -120,6 +120,16 @@ module Oplogjam
         expect { delete.apply('foo.bar' => table) }.to change { table.exclude(deleted_at: nil).count }.by(1)
       end
 
+      it 'sets updated_at against the row' do
+        Timecop.freeze(Time.new(2001, 1, 1, 0, 0, 0)) do
+          table.insert(id: '1', document: '{}', created_at: Time.now.utc)
+          delete = build_delete(1)
+          delete.apply('foo.bar' => table)
+
+          expect(table.first).to include(updated_at: Time.new(2001, 1, 1, 0, 0, 0))
+        end
+      end
+
       it 'ignores deletes for rows that do not exist' do
         delete = build_delete(999)
 

--- a/spec/oplogjam/insert_spec.rb
+++ b/spec/oplogjam/insert_spec.rb
@@ -251,6 +251,16 @@ module Oplogjam
         expect(table.get(Sequel.pg_jsonb_op(:document).get_text('baz'))).to eq('quux')
       end
 
+      it 'updates updated_at for existing records' do
+        Timecop.freeze(Time.new(2001, 1, 1, 0, 0, 0)) do
+          table.insert(id: '1', document: '{}', created_at: Time.now.utc)
+          insert = build_insert(_id: 1, baz: 'quux')
+          insert.apply('foo.bar' => table)
+
+          expect(table.first).to include(updated_at: Time.new(2001, 1, 1, 0, 0, 0))
+        end
+      end
+
       it 'only updates non-deleted records with the same ID' do
         table.insert(id: '1', document: '{"a":1}', created_at: Time.now.utc, deleted_at: Time.now.utc)
         insert = build_insert(_id: 1, a: 2)

--- a/spec/oplogjam/update_spec.rb
+++ b/spec/oplogjam/update_spec.rb
@@ -135,6 +135,16 @@ module Oplogjam
         expect(table.first).to include(document: Sequel.pg_jsonb('_id' => 1, 'foo' => 'bar'))
       end
 
+      it 'updates updated_at' do
+        Timecop.freeze(Time.new(2001, 1, 1, 0, 0, 0)) do
+          table.insert(id: '1', document: '{"_id":1}', created_at: Time.now.utc)
+          update = build_update(1, 'a' => 1)
+          update.apply('foo.bar' => table)
+
+          expect(table.first).to include(updated_at: Time.new(2001, 1, 1, 0, 0, 0))
+        end
+      end
+
       it 'applies {"a"=>1, "b"=>2} to {}' do
         table.insert(id: '1', document: '{"_id":1}', created_at: Time.now.utc)
         update = build_update(1, 'a' => 1, 'b' => 2)


### PR DESCRIPTION
When upserting a record (i.e. inserting the same record twice), set the updated_at timestamp but leave the created_at intact.

When deleting a record, set the updated_at timestamp.