### PR TITLE
Make the 'msg' in a noop optional

### DIFF
--- a/lib/oplogjam/noop.rb
+++ b/lib/oplogjam/noop.rb
@@ -8,7 +8,7 @@ module Oplogjam
       h = bson.fetch(H)
       ts = bson.fetch(TS)
       o = bson.fetch(O)
-      msg = o.fetch(MSG)
+      msg = o.fetch(MSG, nil)
 
       new(h, ts, msg)
     rescue KeyError => e

--- a/spec/oplogjam/noop_spec.rb
+++ b/spec/oplogjam/noop_spec.rb
@@ -16,19 +16,6 @@ module Oplogjam
 
         expect(described_class.from(bson)).to be_a(described_class)
       end
-
-      it 'raises an error if the message is missing' do
-        bson = BSON::Document.new(
-          ts: BSON::Timestamp.new(1_479_419_535, 1),
-          h: -2_135_725_856_567_446_411,
-          v: 2,
-          op: 'n',
-          ns: '',
-          o: BSON::Document.new(foo: 'bar')
-        )
-
-        expect { described_class.from(bson) }.to raise_error(InvalidNoop)
-      end
     end
 
     describe '#message' do
@@ -44,6 +31,20 @@ module Oplogjam
         noop = described_class.from(bson)
 
         expect(noop.message).to eq('initiating set')
+      end
+
+      it 'returns an empty string if the message is not set' do
+        bson = BSON::Document.new(
+          ts: BSON::Timestamp.new(1_479_419_535, 1),
+          h: -2_135_725_856_567_446_411,
+          v: 2,
+          op: 'n',
+          ns: '',
+          o: BSON::Document.new
+        )
+        noop = described_class.from(bson)
+
+        expect(noop.message).to be_empty
       end
     end
 


### PR DESCRIPTION
As this was required before, I didn't want to change to be suprisingly
returning a nil. Anything that someone was doing with this string before
should still work as expected, even if the message is empty now.

I've not been able to track down the schema for the Oplog, but we've run
into a scenario where we have noops which contain the full object in
'o', and do not include 'msg'. This situation could have come about
because of a bug on our side; we upgraded Mongoid for one of our
applications and it/Mongo(?) started producing these odd noop messages.
Our investigation onto how that happened is on going.